### PR TITLE
Fix: the issue with the sound

### DIFF
--- a/include/Assets.hpp
+++ b/include/Assets.hpp
@@ -23,7 +23,7 @@ public:
     [[nodiscard]] const sf::Texture& getTexture(const std::string& texName) const;
     [[nodiscard]] const Animation& getAnimation(const std::string& animName) const;
     [[nodiscard]] const sf::Font& getFont(const std::string& fonrName) const;
-    [[nodiscard]] const sf::Sound& getSound(const std::string& soundName) const;
+    sf::Sound& getSound(const std::string& soundName);
 
 private:
     void addTexture(const std::string& texName, const std::string& path); // bool s

--- a/include/SceneZelda.hpp
+++ b/include/SceneZelda.hpp
@@ -25,6 +25,7 @@ protected:
     void loadLevel(const std::string& filename);
 
     Vec2 getPosition(int rx, int ry, int tx, int ty) const;
+    Vec2 setPosition(const Vec2& vec) const;
     void spawnPlayer();
     void spawnSword(std::shared_ptr<Entity> entity);
     std::shared_ptr<Entity> player();

--- a/src/Assets.cpp
+++ b/src/Assets.cpp
@@ -94,7 +94,7 @@ const sf::Font& Assets::getFont(const std::string& fonrName) const
     return m_fontMap.at(fonrName);
 }
 
-const sf::Sound& Assets::getSound(const std::string& soundName) const
+sf::Sound& Assets::getSound(const std::string& soundName)
 {
     assert(m_soundMap.find(soundName) != m_soundMap.end());
     return m_soundMap.at(soundName);

--- a/src/GameEngine.cpp
+++ b/src/GameEngine.cpp
@@ -40,14 +40,12 @@ void GameEngine::quit()
 
 void GameEngine::playSound(const std::string& soundName)
 {
-    auto sound = assets().getSound(soundName);
-    sound.play();
+    assets().getSound(soundName).play();
 }
 
 void GameEngine::stopSound(const std::string& soundName)
 {
-    auto sound = assets().getSound(soundName);
-    sound.stop();
+    assets().getSound(soundName).stop();
 }
 
 Assets& GameEngine::assets()

--- a/src/SceneZelda.cpp
+++ b/src/SceneZelda.cpp
@@ -1,5 +1,6 @@
 #include "SceneZelda.hpp"
 
+#include <cmath>
 #include <fstream>
 #include <iostream>
 
@@ -424,6 +425,18 @@ Vec2 SceneZelda::getPosition(const int rx, const int ry, const int tx, const int
     };
 }
 
+Vec2 SceneZelda::setPosition(const Vec2& vec) const
+{
+    // TODO: make it to include room also
+    const float tileX = std::round((vec.x - m_gridSize.x / 2.0f) / m_gridSize.x);
+    const float tileY = std::round((vec.y - m_gridSize.y / 2.0f) / m_gridSize.y);
+
+    return {
+        tileX * m_gridSize.x + m_gridSize.x / 2.0f,
+        tileY * m_gridSize.y + m_gridSize.y / 2.0f,
+    };
+}
+
 void SceneZelda::spawnPlayer()
 {
     if (const auto mPlayer = player()) { mPlayer->destroy(); }
@@ -471,7 +484,7 @@ void SceneZelda::sDrag()
         if (e->has<CDraggable>() && e->get<CDraggable>().dragging)
         {
             const Vec2 wPos = windowToWorld(m_mousePos);
-            e->get<CTransform>().pos = wPos;
+            e->get<CTransform>().pos = setPosition(wPos); // snap to grid
         }
     }
 }


### PR DESCRIPTION
There was `auto sound = assets().getSound(soundName);` which created a copy instead of referring to the initialized object in m_soundMap. A reason of incorrect call was the declaration of method with consts `const sf::Sound& getSound(const std::string& soundName) const;`. This should not be, because the object `sf::Sound` should be mutable.